### PR TITLE
don't consume memory to the point of crashing...

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,23 +2,42 @@
  * @module stream-chunk-promise
  */
 
+module.exports = nextChunk;
+
 /**
  * read()s the next chunk of stream and resolve to it, requiring size bytes.
  * @param {ReadableStream} stream
  * @param {integer} size
  * @resolves {Buffer|string} the chunk requested
  */
-module.exports = function nextChunk (stream, size) {
-  return new Promise((resolve, reject) => {
-    stream.once('error', reject);
-    const data = stream.read(size);
-    if (data) {
-      stream.removeListener('error', reject);
-      return resolve(data);
-    }
-    return setImmediate(() => {
-      stream.removeListener('error', reject);
-      resolve(nextChunk(stream, size));
-    });
-  });
-};
+async function nextChunk (stream, size) {
+  // add error handler
+  let error = false;
+  const errorHandler = e => { error = e; };
+  stream.once('error', errorHandler);
+
+  // begin data fetching loop... until we get something.
+  let data = null;
+  // need eslint disable here since it is complaining about error not being
+  // modified in the loop... which it isn't however since this is async it can
+  // still be changed while the loop is running by the error handler above.
+  while (data === null && !error) { // eslint-disable-line no-unmodified-loop-condition
+    data = await stream.read(size);
+    await delay();
+  }
+
+  // remove the error handler
+  stream.removeListener('error', errorHandler);
+
+  // return error... or data.
+  if (error) throw error;
+  return data;
+}
+
+/**
+ * Simple delay function used above inorder to wait for a stream to have data
+ * available.
+ */
+async function delay () {
+  return new Promise(resolve => setImmediate(resolve));
+}


### PR DESCRIPTION
if we are looping for a while waiting for data to be available we shouldn't be consuming gigabytes of memory. Infinite promise chains seem to have issues with memory.

Have changed it to an async while loop which seems to work a whole lot better.